### PR TITLE
Allow untrusted certificates

### DIFF
--- a/kurento-room-client-android/src/main/java/fi/vtt/nubomedia/kurentoroomclientandroid/KurentoRoomAPI.java
+++ b/kurento-room-client-android/src/main/java/fi/vtt/nubomedia/kurentoroomclientandroid/KurentoRoomAPI.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.Vector;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
 import fi.vtt.nubomedia.jsonrpcwsandroid.JsonRpcNotification;
 import fi.vtt.nubomedia.jsonrpcwsandroid.JsonRpcResponse;
 import fi.vtt.nubomedia.utilitiesandroid.LooperExecutor;
@@ -277,7 +279,23 @@ public class KurentoRoomAPI extends KurentoAPI {
                     tmf.init(keyStore);
                     sslContext.init(null, tmf.getTrustManagers(), null);
                 } else {
-                    sslContext.init(null, null, null);
+                    //Allow all certificates
+                    sslContext.init(null, new X509TrustManager[] {
+                            new X509TrustManager() {
+                                @Override
+                                public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                                }
+
+                                @Override
+                                public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                                }
+
+                                @Override
+                                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                                    return new java.security.cert.X509Certificate[0];
+                                }
+                            }
+                    }, null);
                 }
                 webSocketClientFactory = new DefaultSSLWebSocketClientFactory(sslContext);
             }


### PR DESCRIPTION
Hi, 

trying to use the _kurento-room-client-android_ in my project, I've noticed that if I try to establish a websocket connection between the Android API and an app deployed in the PaaS, it fails because of ssl certificates.

I get the following error:
`E/KurentoRoomAPI: onError: Handshake failed
                                                                             javax.net.ssl.SSLHandshakeException: Handshake failed
...                                                                    
Caused by: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.
...`

You can make some test with our application deployed in the PaaS:
https://ob4fb42a1.apps.nubomedia-paas.eu

And the websocket url would be: 
wss://ob4fb42a1.apps.nubomedia-paas.eu/room

If you don't have any other solution for this, I suggest accept any certificate (even untrusted) to make a websocket connection between the _kurento-room-client-android_ API and the PaaS applications.

Of course if you have any question or you want to discuss about this, please contact me.

Regards,
Jorge.